### PR TITLE
Allow for node_module relative paths in LESS

### DIFF
--- a/less-bundle/less-bundle/lib/buildcontents.ts
+++ b/less-bundle/less-bundle/lib/buildcontents.ts
@@ -37,7 +37,15 @@ function buildContents(lines: Array<string>, filePath: string) {
                 imported += '.less';
             }
 
-            hashPath = path.resolve(filePath, '..', imported);
+            // If a path is relative to node_modules, reference the cwd's node_modules folder
+            if (imported.charAt(0) === '~') {
+                console.log('References Node Modules')
+                var deTildedImport = imported.substr(1);
+                hashPath = path.resolve(process.cwd(), 'node_modules', deTildedImport);
+            } else {
+                hashPath = path.resolve(filePath, '..', imported);
+            }
+            
             if (typeof imports[hashPath] === 'undefined') {
                 imports[hashPath] = true;
                 file = fs.readFileSync(hashPath, 'utf8');

--- a/less-bundle/less-bundle/lib/buildcontents.ts
+++ b/less-bundle/less-bundle/lib/buildcontents.ts
@@ -39,7 +39,6 @@ function buildContents(lines: Array<string>, filePath: string) {
 
             // If a path is relative to node_modules, reference the cwd's node_modules folder
             if (imported.charAt(0) === '~') {
-                console.log('References Node Modules')
                 var deTildedImport = imported.substr(1);
                 hashPath = path.resolve(process.cwd(), 'node_modules', deTildedImport);
             } else {


### PR DESCRIPTION
Check for a tilde at the beginning of the path. If it exists, resolve the path relative to the working directory's node_modules folder.

Addresses #2 